### PR TITLE
Fix js error happening with recent chromecast or node.js version

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,9 @@ module.exports = function(opts, cb) {
   var onResponse = function(response) {
     var answer = response.answers[0];
 
-    if (answer.name !== opts.service_name ||
-        answer.type !== opts.service_type) {
+    if (answer &&
+        (answer.name !== opts.service_name ||
+         answer.type !== opts.service_type)) {
       return;
     }
 


### PR DESCRIPTION
We are seeing this error when using castnow:

```
TypeError: Cannot read property 'name' of undefined
    at EventEmitter.onResponse (/usr/local/lib/node_modules/castnow/node_modules/chromecast-player/node_modules/chromecast-scanner/index.js:32:15)
    at emitTwo (events.js:87:13)
    at EventEmitter.emit (events.js:172:7)
    at Socket.<anonymous> (/usr/local/lib/node_modules/castnow/node_modules/chromecast-player/node_modules/chromecast-scanner/node_modules/multicast-dns/index.js:41:45)
    at emitTwo (events.js:87:13)
    at Socket.emit (events.js:172:7)
    at UDP.onMessage (dgram.js:481:8)
```

See xat/castnow#110